### PR TITLE
Feat: Ajout du contrôle d'accès aux projets

### DIFF
--- a/src/Repository/ProjectRepository.php
+++ b/src/Repository/ProjectRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Employee;
 use App\Entity\Project;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -15,6 +16,20 @@ class ProjectRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, Project::class);
     }
+
+        /**
+         * @return Project[] Returns an array of Project objects
+         */
+        public function findByEmployee(Employee $employee): array
+        {
+            return $this->createQueryBuilder('PROJECT')
+                ->innerJoin('PROJECT.employees', 'EMPLOYEE')
+                ->andWhere('EMPLOYEE = :employee')
+                ->setParameter('employee', $employee)
+                ->orderBy('PROJECT.id', 'ASC')
+                ->getQuery()
+                ->getResult();
+        }
 
     //    /**
     //     * @return Project[] Returns an array of Project objects

--- a/src/Security/Voter/IsProjectAssignedVoter.php
+++ b/src/Security/Voter/IsProjectAssignedVoter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Employee;
+use App\Entity\Project;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class IsProjectAssignedVoter extends Voter
+{
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return 'project.is_assigned' === $attribute && $subject instanceof Project;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $employee = $token->getUser();
+        if (!$employee instanceof Employee) {
+            return false;
+        }
+
+        if (in_array('ROLE_ADMIN', $employee->getRoles())) {
+            return true;
+        }
+
+        /* @var Project $subject */
+        $employeeProjects = $employee->getProjects();
+        foreach ($employeeProjects as $employeeProject) {
+            if ($employeeProject->getId() === $subject->getId()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Description
Cette PR implémente un système de contrôle d'accès permettant de restreindre l'accès aux projets uniquement aux employés qui y sont assignés.
## Changements effectués
- ✨ Création d'un nouveau pour la gestion des permissions `IsProjectAssignedVoter`
- 🔄 Ajout de la méthode `findByEmployee()` dans `ProjectRepository`
- 🛠️ Mise à jour du pour intégrer les nouveaux contrôles d'accès `ProjectController`
- 🚫 Restriction de l'accès aux projets pour les utilisateurs non-administrateurs
