### PR TITLE
Add role selection to employee form and update styles

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -574,7 +574,7 @@ form label {
   flex-grow: 0;
 }
 
-button.button.button-submit input.button.button-submit {
+button.button.button-submit {
   width: 100%;
   background: #1f5b50;
   border-radius: 10px;
@@ -681,5 +681,13 @@ form
   ul#main-menu li a {
     border-radius: 0;
     padding: 13px;
+  }
+
+  .form-switch {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: row;
+    gap: 10px;
   }
 }

--- a/src/Controller/EmployeeController.php
+++ b/src/Controller/EmployeeController.php
@@ -50,6 +50,8 @@ final class EmployeeController extends AbstractController
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
+            $roles = $form->get('roles')->getData();
+            $employee->setRoles([$roles]);
             $entityManager->persist($employee);
             $entityManager->flush();
             return $this->redirectToRoute('app_employee_index');

--- a/src/Form/EmployeeType.php
+++ b/src/Form/EmployeeType.php
@@ -8,6 +8,7 @@ use App\Entity\Role;
 use App\Entity\Task;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -47,7 +48,16 @@ class EmployeeType extends AbstractType
                     'placeholder' => 'Entrez le type de contrat',
                 ],
             ])
-        ;
+            ->add('roles', ChoiceType::class, [
+                'label' => 'Administrateur ?',
+                'choices' => [
+                    'Non' => 'ROLE_USER',
+                    'Oui' => 'ROLE_ADMIN',
+                ],
+                'expanded' => false,
+                'multiple' => false,
+                'mapped' => false,
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/templates/employee/edit.html.twig
+++ b/templates/employee/edit.html.twig
@@ -21,6 +21,7 @@
         {{ form_row(form.hiring_date)  }}
         {{ form_row(form.contract) }}
     </div>
+    {{ form_row(form.roles) }}
     <button class="button button-submit">Enregistrer</button>
     {{ form_end(form) }}
 {% endblock %}


### PR DESCRIPTION
- Added "roles" field in `EmployeeType` form for admin/user selection.
- Updated `EmployeeController` to handle role assignment.
- Adjusted `edit.html.twig` template to include roles input.
- Improved button styling and added `.form-switch` styles in CSS.